### PR TITLE
Fix broken anchor thing; add post page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Website link](https://moyapchen.github.io)
 
-This is my personal above-the-fold web page, using the [Poole Jekyll](https://github.com/poole/lanyon) theme, with some [Tufte-style footnotes](https://github.com/clayh53/tufte-jekyll/blob/master/_plugins/sidenote.rb) cause I have a hard time not adding in something a little wonky :)   
+This is my personal above-the-fold web page, using the [Poole Jekyll](https://github.com/poole/lanyon) theme, with some [Tufte-style footnotes](https://github.com/clayh53/tufte-jekyll/blob/master/_plugins/sidenote.rb) cause footnotes are great :)   
 
 ## Author
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,7 +20,7 @@
       </div>
 
       <div class="container content">
-        {% include anchor_headings.html html=content anchorBody="#" %}
+        {{ content }} 
       </div>
     </div>
 

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -4,5 +4,6 @@ layout: default
 
 <div class="page">
   <h1 class="page-title">{{ page.title }}</h1>
-    {{ content }}
+
+    {% include anchor_headings.html html=content anchorBody="#" %}
 </div>

--- a/_layouts/page_not_sidebar.html
+++ b/_layouts/page_not_sidebar.html
@@ -5,5 +5,5 @@ layout: default
 <div class="page">
   <h1 class="page-title">{{ page.title }}</h1>
   <hr>
-    {{ content }} 
+  {% include anchor_headings.html html=content anchorBody="#" %}
 </div>

--- a/_layouts/page_not_sidebar_no_title.html
+++ b/_layouts/page_not_sidebar_no_title.html
@@ -3,5 +3,5 @@ layout: default
 ---
 
 <div class="page">
-    {{ content }} 
+    {% include anchor_headings.html html=content anchorBody="#" %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,9 +3,8 @@ layout: default
 ---
 
 <div class="post">
-
+<a href="{{ page.url | absolute_url }}">
 {% if page.headerImage %}
-
 <div style="position:relative"> 
     <img src="{{ 'public/blog_images/headers/' | append: page.headerImage | relative_url }}" />
     <div style="position:absolute; bottom: 8px; left: 16px;">
@@ -23,6 +22,7 @@ layout: default
 </h1>
 
 {% endif %} 
+</a>
 
   <span class="post-date">{{ page.date | date_to_string }}
       | Tags: 
@@ -30,7 +30,8 @@ layout: default
           <a href="{{ '/blog/tags/' | append: tag | absolute_url }}"> {{tag}} </a> ∗ 
        {% endfor %}
    </span>
-    {{ content }}
+   {% include anchor_headings.html html=content anchorBody="#" %}
+
 </div>
 
 <hr>


### PR DESCRIPTION
Fix https://github.com/moyapchen/moyapchen.github.io/issues/50

Answer turned out to be pretty easy when I was looking through old commits for context as to how I set up the anchor system — turns out, I did https://github.com/moyapchen/moyapchen.github.io/pull/16 backwards and should've removed the code in "default.html"  but kept the ones for individual layouts, rather than the other-way-around that I did in that PR.

Minor README wording update.

Also add it so that posts will auto link to themselves upon clicking on the image/post title.